### PR TITLE
Little Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,39 @@ The folder `frontend` contains the source code of the UI. The folder `backend-de
 ### How to run:
 
 - Get the latest docker image for MigratoryData server using the following command:
-      
+
+      ```bash
       docker compose pull
+      ```
 
 - Start Kafka, Ksqldb and Migratorydata using docker-compose.yml file from backend-deployment running command:
 
+      ```bash
       docker compose up
+      ```
 
 - Add ksql streams from file KSQL-GAMIFICATION-STREAMS.sql:
 
+      ```bash
       docker exec -it ksqldb-cli ksql --file /ksql-gamification-streams/KSQL-GAMIFICATION-STREAMS.sql http://ksqldb-server:8088
+      ```
 
 - Open a browser and go to url http://localhost:8800 to open realtime gamification app.
 
 - Publish a question using command:
 
+      ```bash
       docker exec -it ksqldb-cli ksql --execute "INSERT INTO INPUT_QUESTION (id, question, answers, answer, points) VALUES ('id-1', 'How many spectators are there altogether?', ARRAY['less than 1000', 'between 1000 and 5000', 'between 5000 and 10000', 'more than 10000'], 'between 1000 and 5000', 100)" http://ksqldb-server:8088
 
       docker exec -it ksqldb-cli ksql --execute "INSERT INTO INPUT_QUESTION (id, question, answers, answer, points) VALUES ('id-2', 'What is the number of strokes with which this game will be won?', ARRAY['less than 10', 'between 10 and 20', 'between 20 and 30', 'more than 30'], 'more than 30', 100)" http://ksqldb-server:8088
 
       docker exec -it ksqldb-cli ksql --execute "INSERT INTO INPUT_QUESTION (id, question, answers, answer, points) VALUES ('id-3', 'Who will win this game?', ARRAY['Simona Halep', 'Sloane Stephens'], 'Sloane Stephens', 100)" http://ksqldb-server:8088
+      ```
 
 - Answer to the published question in the browser.
 
 - Remove stopped containers and volumes created for this demo running the command:
-      
+
+      ```bash
       docker compose rm -v
+      ```

--- a/backend-deployment/docker-compose.yml
+++ b/backend-deployment/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '2'
-
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0

--- a/backend-deployment/docker-compose.yml
+++ b/backend-deployment/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "9101:9101"
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
@@ -48,8 +48,8 @@ services:
       KSQL_LISTENERS: "http://0.0.0.0:8088"
       KSQL_CACHE_MAX_BYTES_BUFFERING: 0
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_REPLICATION_FACTOR: 1
-      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: 'true'
-      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: 'true'
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
 
   ksqldb-cli:
     image: confluentinc/cp-ksqldb-cli:7.5.0
@@ -71,7 +71,7 @@ services:
     ports:
       - "8800:8800"
     environment:
-      MIGRATORYDATA_EXTRA_OPTS: '-DMemory=128MB -DLogLevel=INFO -DX.ConnectionOffload=true -DClusterEngine=kafka'
-      MIGRATORYDATA_KAFKA_EXTRA_OPTS: '-Dbootstrap.servers=broker:29092 -Dtopics=question,result,top,live'
+      MIGRATORYDATA_EXTRA_OPTS: "-DMemory=128MB -DLogLevel=INFO -DX.ConnectionOffload=true -DClusterEngine=kafka"
+      MIGRATORYDATA_KAFKA_EXTRA_OPTS: "-Dbootstrap.servers=broker:29092 -Dtopics=question,result,top,live"
     volumes:
       - ../frontend:/migratorydata/html


### PR DESCRIPTION
## What's Changed

- Remove the top-level `version` property of `docker-compose.yml` file. It's [deprecated](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete).
- Format the `docker-compose.yml` file and use double quotes everywhere.
- Format `README.md` file. Use proper code clock styles for bash commands.